### PR TITLE
Make PractRand available

### DIFF
--- a/PractRand/default.nix
+++ b/PractRand/default.nix
@@ -1,0 +1,34 @@
+{ stdenv, fetchurl, unzip }:
+
+stdenv.mkDerivation {
+  name = "PractRand";
+  src = fetchurl {
+    url = "https://downloads.sourceforge.net/project/pracrand/PractRand_0.93.zip";
+    sha256 = "18s65qy2j0p6n5fw5qk84qnrdg0ckchy2ah7bx05w8iyzsyl40bn";
+  };
+  nativeBuildInputs = [ unzip ];
+
+  unpackPhase = ''
+    unzip -q $src
+  '';
+  patchPhase = ''
+    patch -p0 < ${./practrand-0.93-bigbuffer.patch}
+  '';
+  buildPhase = ''
+    g++ -std=c++14 -c src/*.cpp src/RNGs/*.cpp src/RNGs/other/*.cpp -O3 -Iinclude -pthread
+    ar rcs libPractRand.a *.o
+    rm *.o
+    g++ -std=c++14 -o RNG_test tools/RNG_test.cpp libPractRand.a -O3 -Iinclude -pthread
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp RNG_test $out/bin
+  '';
+
+  meta = with stdenv.lib; {
+    description = "C++ library of pseudo-random number generators and statistical tests for RNGs.";
+    license = licenses.publicDomain;
+    homepage = http://pracrand.sourceforge.net/;
+    maintainers = [ maintainers.idontgetoutmuch ];
+  };
+}

--- a/PractRand/practrand-0.93-bigbuffer.patch
+++ b/PractRand/practrand-0.93-bigbuffer.patch
@@ -1,0 +1,24 @@
+diff -ru ./tools/RNG_from_name.h /home/oneill/PractRand/tools/RNG_from_name.h
+--- tools/RNG_from_name.h.orig	2016-09-20 00:46:54.000000000 -0700
++++ tools/RNG_from_name.h	2017-07-02 16:14:14.081560302 -0700
+@@ -8,7 +8,7 @@
+ 			std::fprintf(stderr, "error reading standard input\n");
+ 			std::exit(0);
+ 		}
+-		enum { BUFF_SIZE = 4096 / sizeof(Word) };
++		enum { BUFF_SIZE = 1048576 / sizeof(Word) };
+ 		Word *pos, *end;
+ 		bool ended;
+ 		Word buffer[BUFF_SIZE];
+@@ -19,7 +19,10 @@
+ 			end = &buffer[n];
+ 		}
+ 	public:
+-		_stdin_reader() : ended(false) { refill(); }
++		_stdin_reader() : ended(false) {
++		    setvbuf(stdin, 0, _IOFBF, 1048576);
++		    refill();
++		}
+ 		Word read() { Word rv = *(pos++); if (pos == end) refill(); return rv; }
+ 	};
+ 	class RNG_stdin : public PractRand::RNGs::vRNG8 {

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,7 @@
 let overlay = self: super:
 {
   testu01 = self.callPackage ./TestU01 { };
+  practrand = self.callPackage ./PractRand { };
 };
 
 in
@@ -11,6 +12,7 @@ nixpkgs.stdenv.mkDerivation {
   name = "env";
   buildInputs = [
     nixpkgs.testu01
+    nixpkgs.practrand
   ];
 }
 


### PR DESCRIPTION
Makes PractRand's `RNG_test` binary available to the Nix shell.