### PR TITLE
Patch dieharder

### DIFF
--- a/dieharder/default.nix
+++ b/dieharder/default.nix
@@ -9,6 +9,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ gsl ];
   buildInputs = [ ];
   configureFlags = [ "--disable-shared" ];
+  patchPhase = ''
+    patch -p1 < ${./dieharder-3.31.1-fix-intptr_t-error.patch}
+  '';
 
   meta = with stdenv.lib; {
     description = "Suite of Random Number Tests";

--- a/dieharder/dieharder-3.31.1-fix-intptr_t-error.patch
+++ b/dieharder/dieharder-3.31.1-fix-intptr_t-error.patch
@@ -1,0 +1,12 @@
+diff --git a/include/dieharder/libdieharder.h b/include/dieharder/libdieharder.h
+index 2138ebf..690cf7e 100644
+--- a/include/dieharder/libdieharder.h
++++ b/include/dieharder/libdieharder.h
+@@ -19,6 +19,7 @@
+ #define __USE_MISC 1
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <stdint.h>
+ #include <unistd.h>
+ 
+ /* This turns on M_PI in math.h */


### PR DESCRIPTION
Fixes compilation error with `intptr_t`:

```
In file included from ../include/dieharder/libdieharder.h:22,
                 from bits.c:7:
/nix/store/jk3nrdm3jd67i897db9dcpam75gh3iw6-glibc-2.27-dev/include/unistd.h:1044:20: error: unknown type name 'intptr_t'; did you mean 'int64_t'?
 extern void *sbrk (intptr_t __delta) __THROW;
                    ^~~~~~~~
                    int64_t
```